### PR TITLE
Add Hogebrug status checker CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.pyc
+.venv/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,72 @@
-# galeracluster
+# Hogebrug status checker
+
+Deze repository bevat een klein Python-hulpprogramma dat de actuele status van
+**de Hogebrug in Overschie** probeert te bepalen via het open-data portaal van
+Rotterdam. De logica is defensief opgebouwd zodat kleine wijzigingen in de
+brondata opgevangen kunnen worden.
+
+## Installatie
+
+Het project gebruikt een moderne Python toolchain (Python 3.10 of hoger).
+Installeer eerst de afhankelijkheden:
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -e .[dev]
+```
+
+## Gebruik
+
+Voer de CLI uit met:
+
+```bash
+python -m hogebrug_status
+```
+
+Standaard worden de vijf meest recente records van het dataset `brugopeningen`
+ogevraagd. De CLI toont een compacte tekstuele status, inclusief de meest
+recente observatietijd en de bron-URL.
+
+Belangrijke opties:
+
+- `--bridge`: voer een andere brugnaam in (standaard: `Hogebrug`).
+- `--dataset`: wijzig het dataset-id wanneer Rotterdam het dataportaal aanpast
+  (standaard: `brugopeningen`).
+- `--rows`: hoeveel records moeten worden opgehaald om een status te bepalen
+  (standaard: 5).
+- `--url`: override voor het API-endpoint wanneer het portaal verandert.
+- `--json`: toon de ruwe interpretatie als JSON in plaats van tekst.
+
+Voorbeeld uitvoer:
+
+```
+De Hogebrug is open. (Veld 'melding' meldt: Brug weer open voor verkeer)
+Laatste melding: 2024-04-20T11:00:00+02:00
+Bron: https://opendata.rotterdam.nl/api/records/1.0/search/
+```
+
+## Testen
+
+Tests draaien met `pytest`:
+
+```bash
+pytest
+```
+
+De tests dekken zowel de interpretatielogica als de CLI.
+
+## Hoe het werkt
+
+1. De `BridgeStatusChecker` haalt records op uit het open-data portaal waarbij
+   gezocht wordt op de opgegeven brugnaam.
+2. Voor elk record probeert de checker meerdere strategieën:
+   - Tekstvelden met woorden zoals "open" of "dicht" worden herkend.
+   - Datum- en tijdvelden met woorden als `opening` of `sluiting` worden
+     vergeleken om te bepalen of een sluiting bekend is.
+   - Booleaanse of 0/1 velden worden geïnterpreteerd als directe status.
+3. Het meest recente record met een herleidbare status wordt teruggegeven.
+
+Als geen enkele strategie slaagt, meldt de CLI dat de status niet bepaald kon
+worden. Pas in dat geval de dataset-instellingen aan of controleer handmatig de
+open-data bron.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,21 @@
+[build-system]
+requires = ["setuptools>=67", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "hogebrug-status"
+version = "0.1.0"
+description = "CLI hulpprogramma om de status van de Hogebrug op te vragen"
+authors = [{name = "AI Assistant"}]
+readme = "README.md"
+requires-python = ">=3.10"
+dependencies = []
+
+[project.optional-dependencies]
+dev = [
+  "pytest>=7.4",
+]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+addopts = "-q"

--- a/src/hogebrug_status/__init__.py
+++ b/src/hogebrug_status/__init__.py
@@ -1,0 +1,9 @@
+"""Utilities to determine the status of the Hogebrug in Overschie."""
+
+from .checker import BridgeStatus, BridgeStatusChecker, BridgeStatusError
+
+__all__ = [
+    "BridgeStatus",
+    "BridgeStatusChecker",
+    "BridgeStatusError",
+]

--- a/src/hogebrug_status/__main__.py
+++ b/src/hogebrug_status/__main__.py
@@ -1,0 +1,6 @@
+"""Module entry-point to run the CLI via ``python -m hogebrug_status``."""
+
+from .cli import main
+
+if __name__ == "__main__":  # pragma: no cover - delegated to cli
+    raise SystemExit(main())

--- a/src/hogebrug_status/checker.py
+++ b/src/hogebrug_status/checker.py
@@ -1,0 +1,308 @@
+"""Core logic for determining the Hogebrug bridge status.
+
+The application uses the public Rotterdam open data portal. Because the data
+model of the datasets on the portal can change over time, the logic in this
+module is intentionally defensive: it tries to interpret a record in multiple
+ways before giving up.
+"""
+
+from __future__ import annotations
+
+import datetime as _dt
+import json
+from dataclasses import dataclass
+from typing import Any, Dict, Iterable, List, Mapping, Optional
+from urllib import error as _urlerror
+from urllib import parse as _urlparse
+from urllib import request as _urlrequest
+
+__all__ = ["BridgeStatus", "BridgeStatusChecker", "BridgeStatusError"]
+
+
+DEFAULT_DATASET = "brugopeningen"
+DEFAULT_URL = "https://opendata.rotterdam.nl/api/records/1.0/search/"
+DEFAULT_ROWS = 5
+DEFAULT_TIMEOUT = 10
+
+OPEN_KEYWORDS = {
+    "open",
+    "weer open",
+    "openstaand",
+    "open voor verkeer",
+    "open voor scheepvaart",
+    "vrijgegeven",
+}
+CLOSED_KEYWORDS = {
+    "dicht",
+    "gesloten",
+    "afgesloten",
+    "gestremd",
+    "stremming",
+}
+
+
+class BridgeStatusError(RuntimeError):
+    """Raised when the bridge status could not be determined."""
+
+
+@dataclass(frozen=True)
+class BridgeStatus:
+    """Represents the interpreted status for a bridge."""
+
+    is_open: Optional[bool]
+    summary: str
+    observed_at: Optional[_dt.datetime]
+    source_url: str
+    raw_fields: Mapping[str, Any]
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Return a serialisable representation for JSON output."""
+
+        return {
+            "is_open": self.is_open,
+            "summary": self.summary,
+            "observed_at": self.observed_at.isoformat() if self.observed_at else None,
+            "source_url": self.source_url,
+            "raw_fields": self._json_safe(self.raw_fields),
+        }
+
+    @staticmethod
+    def _json_safe(value: Any) -> Any:
+        try:
+            json.dumps(value)
+            return value
+        except TypeError:
+            if isinstance(value, Mapping):
+                return {k: BridgeStatus._json_safe(v) for k, v in value.items()}
+            if isinstance(value, Iterable) and not isinstance(value, (str, bytes)):
+                return [BridgeStatus._json_safe(v) for v in value]
+            return str(value)
+
+    @property
+    def label(self) -> str:
+        if self.is_open is True:
+            return "open"
+        if self.is_open is False:
+            return "dicht"
+        return "onbekend"
+
+
+class BridgeStatusChecker:
+    """Fetch and interpret the Hogebrug status from Rotterdam open data."""
+
+    def __init__(
+        self,
+        *,
+        dataset: str = DEFAULT_DATASET,
+        bridge_name: str = "Hogebrug",
+        base_url: str = DEFAULT_URL,
+        rows: int = DEFAULT_ROWS,
+        timeout: int = DEFAULT_TIMEOUT,
+        opener: Optional[_urlrequest.OpenerDirector] = None,
+    ) -> None:
+        self.dataset = dataset
+        self.bridge_name = bridge_name
+        self.base_url = base_url
+        self.rows = rows
+        self.timeout = timeout
+        self._opener = opener or _urlrequest.build_opener()
+        self._last_url: Optional[str] = None
+
+    def get_status(self) -> BridgeStatus:
+        """Return the most recent known bridge status."""
+
+        payload = self._download()
+        records = self._extract_records(payload)
+        if not records:
+            raise BridgeStatusError("Geen gegevens ontvangen van de open-data bron.")
+
+        statuses = [self._record_to_status(record) for record in records]
+        statuses = [status for status in statuses if status is not None]
+        if not statuses:
+            raise BridgeStatusError("Kon de status niet interpreteren uit de brongegevens.")
+
+        statuses.sort(key=lambda s: s.observed_at or _dt.datetime.min.replace(tzinfo=_dt.timezone.utc), reverse=True)
+        for status in statuses:
+            if status.is_open is not None:
+                return status
+        return statuses[0]
+
+    # ------------------------------------------------------------------
+    # Network helpers
+    def _download(self) -> Mapping[str, Any]:
+        params = {
+            "dataset": self.dataset,
+            "q": self.bridge_name,
+            "rows": self.rows,
+            "sort": "-record_timestamp",
+        }
+        query = _urlparse.urlencode(params, doseq=True)
+        url = f"{self.base_url}?{query}" if query else self.base_url
+        self._last_url = url
+        try:
+            with self._opener.open(url, timeout=self.timeout) as response:
+                status_code = getattr(response, "status", None) or response.getcode()
+                if status_code and status_code >= 400:
+                    raise BridgeStatusError(
+                        f"De open-data bron gaf een foutmelding ({status_code})."
+                    )
+                raw = response.read()
+        except _urlerror.URLError as exc:
+            raise BridgeStatusError(f"Netwerkfout tijdens ophalen gegevens: {exc}") from exc
+
+        try:
+            text = raw.decode("utf-8")
+        except UnicodeDecodeError:
+            text = raw.decode("latin-1")
+        try:
+            return json.loads(text)
+        except ValueError as exc:
+            raise BridgeStatusError("Kon de JSON-respons niet lezen.") from exc
+
+    def _extract_records(self, payload: Mapping[str, Any]) -> List[Mapping[str, Any]]:
+        if not isinstance(payload, Mapping):
+            return []
+        for key in ("records", "results", "data"):
+            value = payload.get(key)
+            if isinstance(value, list):
+                return [item for item in value if isinstance(item, Mapping)]
+        return []
+
+    # ------------------------------------------------------------------
+    # Interpretation logic
+    def _record_to_status(self, record: Mapping[str, Any]) -> Optional[BridgeStatus]:
+        fields = self._extract_fields(record)
+        observed_at = self._determine_observed_at(record, fields)
+        summary_prefix = "Brongegevens konden niet geïnterpreteerd worden"
+        interpreted_status = self._interpret_status(fields)
+        if interpreted_status is None:
+            return None
+        is_open, summary = interpreted_status
+        full_summary = summary if summary else summary_prefix
+        return BridgeStatus(
+            is_open=is_open,
+            summary=full_summary,
+            observed_at=observed_at,
+            source_url=self._source_url(),
+            raw_fields=fields,
+        )
+
+    def _extract_fields(self, record: Mapping[str, Any]) -> Mapping[str, Any]:
+        if "fields" in record and isinstance(record["fields"], Mapping):
+            return record["fields"]  # type: ignore[return-value]
+        return record
+
+    def _determine_observed_at(
+        self, record: Mapping[str, Any], fields: Mapping[str, Any]
+    ) -> Optional[_dt.datetime]:
+        candidates: List[_dt.datetime] = []
+        record_timestamp = record.get("record_timestamp")
+        dt = self._parse_datetime(record_timestamp)
+        if dt:
+            candidates.append(dt)
+        for key, value in fields.items():
+            dt = self._parse_datetime(value)
+            if dt:
+                candidates.append(dt)
+        if not candidates:
+            return None
+        candidates.sort()
+        return candidates[-1]
+
+    def _interpret_status(self, fields: Mapping[str, Any]) -> Optional[tuple[Optional[bool], str]]:
+        textual = self._status_from_textual_fields(fields)
+        if textual is not None:
+            return textual
+        temporal = self._status_from_temporal_fields(fields)
+        if temporal is not None:
+            return temporal
+        boolean = self._status_from_boolean_fields(fields)
+        if boolean is not None:
+            return boolean
+        return None
+
+    def _status_from_textual_fields(self, fields: Mapping[str, Any]) -> Optional[tuple[Optional[bool], str]]:
+        for key, value in fields.items():
+            if not isinstance(value, str):
+                continue
+            normalized = value.strip().lower()
+            if not normalized:
+                continue
+            if any(keyword in normalized for keyword in OPEN_KEYWORDS):
+                return True, f"Veld '{key}' meldt: {value}"
+            if any(keyword in normalized for keyword in CLOSED_KEYWORDS):
+                return False, f"Veld '{key}' meldt: {value}"
+        return None
+
+    def _status_from_temporal_fields(self, fields: Mapping[str, Any]) -> Optional[tuple[Optional[bool], str]]:
+        open_candidates: List[_dt.datetime] = []
+        close_candidates: List[_dt.datetime] = []
+        for key, value in fields.items():
+            dt = self._parse_datetime(value)
+            if not dt:
+                continue
+            lower_key = key.lower()
+            if any(token in lower_key for token in ("open", "start", "begin")):
+                open_candidates.append(dt)
+            if any(token in lower_key for token in ("dicht", "sluit", "eind", "close")):
+                close_candidates.append(dt)
+        if not open_candidates and not close_candidates:
+            return None
+        open_dt = max(open_candidates) if open_candidates else None
+        close_dt = max(close_candidates) if close_candidates else None
+        if open_dt and (not close_dt or close_dt < open_dt):
+            return True, "Laatste melding bevat geen sluitingstijd."
+        if close_dt and (not open_dt or close_dt >= open_dt):
+            return False, "Laatste melding bevat een sluitingstijd."
+        return None
+
+    def _status_from_boolean_fields(self, fields: Mapping[str, Any]) -> Optional[tuple[Optional[bool], str]]:
+        for key, value in fields.items():
+            if isinstance(value, bool):
+                return bool(value), f"Booleaanse status in veld '{key}'."
+            if isinstance(value, (int, float)) and value in (0, 1):
+                interpreted = bool(value)
+                return interpreted, f"Numerieke status in veld '{key}'."
+        return None
+
+    # ------------------------------------------------------------------
+    # Helpers
+    def _parse_datetime(self, value: Any) -> Optional[_dt.datetime]:
+        if isinstance(value, _dt.datetime):
+            return value if value.tzinfo else value.replace(tzinfo=_dt.timezone.utc)
+        if isinstance(value, (int, float)):
+            if value > 1e12:
+                value = value / 1000.0
+            try:
+                return _dt.datetime.fromtimestamp(value, tz=_dt.timezone.utc)
+            except (OverflowError, OSError):
+                return None
+        if not isinstance(value, str):
+            return None
+        cleaned = value.strip()
+        if not cleaned:
+            return None
+        cleaned = cleaned.replace("Z", "+00:00")
+        try:
+            return _dt.datetime.fromisoformat(cleaned)
+        except ValueError:
+            pass
+        fmts = [
+            "%Y-%m-%d %H:%M:%S",
+            "%Y-%m-%d %H:%M",
+            "%d-%m-%Y %H:%M:%S",
+            "%d-%m-%Y %H:%M",
+        ]
+        for fmt in fmts:
+            try:
+                naive = _dt.datetime.strptime(cleaned, fmt)
+            except ValueError:
+                continue
+            return naive.replace(tzinfo=_dt.timezone.utc)
+        return None
+
+    def _source_url(self) -> str:
+        return self._last_url or self.base_url
+
+
+__all__ = ["BridgeStatus", "BridgeStatusChecker", "BridgeStatusError"]

--- a/src/hogebrug_status/cli.py
+++ b/src/hogebrug_status/cli.py
@@ -1,0 +1,74 @@
+"""Command line interface to inspect the Hogebrug status."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from typing import Iterable, Optional
+
+from .checker import BridgeStatusChecker, BridgeStatusError
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Controleer de actuele status van de Hogebrug in Overschie."
+    )
+    parser.add_argument(
+        "--bridge",
+        default="Hogebrug",
+        help="Naam van de brug waarvoor de status opgevraagd moet worden.",
+    )
+    parser.add_argument(
+        "--dataset",
+        default="brugopeningen",
+        help="Naam van het dataset-id op het Rotterdam open data portaal.",
+    )
+    parser.add_argument(
+        "--rows",
+        type=int,
+        default=5,
+        help="Aantal records dat opgehaald wordt om de status te bepalen.",
+    )
+    parser.add_argument(
+        "--url",
+        default="https://opendata.rotterdam.nl/api/records/1.0/search/",
+        help="API-endpoint van het open data portaal.",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Toon het resultaat als JSON in plaats van tekst.",
+    )
+    return parser
+
+
+def main(argv: Optional[Iterable[str]] = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(list(argv) if argv is not None else None)
+
+    checker = BridgeStatusChecker(
+        dataset=args.dataset,
+        bridge_name=args.bridge,
+        base_url=args.url,
+        rows=args.rows,
+    )
+
+    try:
+        status = checker.get_status()
+    except BridgeStatusError as exc:
+        print(f"Kon de brugstatus niet bepalen: {exc}", file=sys.stderr)
+        return 1
+
+    if args.json:
+        print(json.dumps(status.to_dict(), ensure_ascii=False, indent=2))
+    else:
+        observed = status.observed_at.isoformat() if status.observed_at else "onbekend"
+        print(f"De {args.bridge} is {status.label}. ({status.summary})")
+        print(f"Laatste melding: {observed}")
+        print(f"Bron: {status.source_url}")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entry point
+    raise SystemExit(main())

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,7 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+SRC = ROOT / "src"
+if SRC.exists():
+    sys.path.insert(0, str(SRC))

--- a/tests/test_checker.py
+++ b/tests/test_checker.py
@@ -1,0 +1,164 @@
+import json
+from urllib import error as urlerror
+
+import pytest
+
+from hogebrug_status.checker import BridgeStatusChecker, BridgeStatusError
+
+
+class DummyResponse:
+    def __init__(self, json_data, status=200, raw_bytes=None):
+        self._json_data = json_data
+        self.status = status
+        self._raw_bytes = raw_bytes
+
+    def read(self):
+        if self._raw_bytes is not None:
+            return self._raw_bytes
+        return json.dumps(self._json_data).encode("utf-8")
+
+    def getcode(self):
+        return self.status
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+
+class DummyOpener:
+    def __init__(self, response):
+        self.response = response
+        self.open_calls = []
+
+    def open(self, url, timeout=None):
+        self.open_calls.append({"url": url, "timeout": timeout})
+        if isinstance(self.response, Exception):
+            raise self.response
+        return self.response
+
+
+def build_checker(response):
+    opener = DummyOpener(response)
+    checker = BridgeStatusChecker(opener=opener)
+    return checker, opener
+
+
+def test_textual_open_status():
+    response = DummyResponse(
+        {
+            "records": [
+                {
+                    "record_timestamp": "2024-04-20T11:00:00+02:00",
+                    "fields": {"melding": "Brug weer open voor verkeer"},
+                }
+            ]
+        }
+    )
+    checker, opener = build_checker(response)
+    status = checker.get_status()
+    assert status.is_open is True
+    assert "weer open" in status.summary.lower()
+    assert status.observed_at.isoformat().startswith("2024-04-20")
+    assert "dataset=brugopeningen" in opener.open_calls[0]["url"]
+
+
+def test_textual_closed_status():
+    response = DummyResponse(
+        {
+            "records": [
+                {
+                    "record_timestamp": "2024-04-21T11:00:00+02:00",
+                    "fields": {"opmerking": "Brug dicht vanwege onderhoud"},
+                }
+            ]
+        }
+    )
+    checker, _ = build_checker(response)
+    status = checker.get_status()
+    assert status.is_open is False
+    assert "dicht" in status.summary.lower()
+
+
+def test_boolean_status():
+    response = DummyResponse(
+        {
+            "records": [
+                {
+                    "record_timestamp": "2024-04-22T08:00:00+02:00",
+                    "fields": {"is_open": True},
+                }
+            ]
+        }
+    )
+    checker, _ = build_checker(response)
+    status = checker.get_status()
+    assert status.is_open is True
+
+
+def test_temporal_status_infers_open():
+    response = DummyResponse(
+        {
+            "records": [
+                {
+                    "record_timestamp": "2024-04-23T10:00:00+02:00",
+                    "fields": {
+                        "opening_start": "2024-04-23T09:50:00+02:00",
+                    },
+                }
+            ]
+        }
+    )
+    checker, _ = build_checker(response)
+    status = checker.get_status()
+    assert status.is_open is True
+    assert "geen sluitingstijd" in status.summary.lower()
+
+
+def test_temporal_status_infers_closed():
+    response = DummyResponse(
+        {
+            "records": [
+                {
+                    "record_timestamp": "2024-04-24T10:00:00+02:00",
+                    "fields": {
+                        "opening_start": "2024-04-24T09:50:00+02:00",
+                        "sluiting": "2024-04-24T09:55:00+02:00",
+                    },
+                }
+            ]
+        }
+    )
+    checker, _ = build_checker(response)
+    status = checker.get_status()
+    assert status.is_open is False
+    assert "sluitingstijd" in status.summary.lower()
+
+
+def test_no_records_raises():
+    response = DummyResponse({"records": []})
+    checker, _ = build_checker(response)
+    with pytest.raises(BridgeStatusError):
+        checker.get_status()
+
+
+def test_http_error_raises():
+    response = DummyResponse({}, status=500)
+    checker, _ = build_checker(response)
+    with pytest.raises(BridgeStatusError):
+        checker.get_status()
+
+
+def test_invalid_json_raises():
+    response = DummyResponse({}, raw_bytes=b"not-json")
+    checker, _ = build_checker(response)
+    with pytest.raises(BridgeStatusError):
+        checker.get_status()
+
+
+def test_network_error_raises():
+    opener_error = urlerror.URLError("kapot")
+    checker, _ = build_checker(opener_error)
+    with pytest.raises(BridgeStatusError):
+        checker.get_status()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,48 @@
+import json
+from unittest.mock import patch
+
+from hogebrug_status.cli import main
+from hogebrug_status.checker import BridgeStatus, BridgeStatusError
+
+
+def build_status(is_open=True):
+    return BridgeStatus(
+        is_open=is_open,
+        summary="Teststatus",
+        observed_at=None,
+        source_url="http://example.com",
+        raw_fields={},
+    )
+
+
+def test_cli_text_output(capsys):
+    with patch("hogebrug_status.cli.BridgeStatusChecker") as mock_checker:
+        mock_checker.return_value.get_status.return_value = build_status(True)
+        exit_code = main(["--bridge", "Hogebrug"])
+
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    assert "is open" in captured.out
+    assert "Bron: http://example.com" in captured.out
+
+
+def test_cli_json_output(capsys):
+    with patch("hogebrug_status.cli.BridgeStatusChecker") as mock_checker:
+        mock_checker.return_value.get_status.return_value = build_status(False)
+        exit_code = main(["--json"])
+
+    assert exit_code == 0
+    captured = capsys.readouterr()
+    data = json.loads(captured.out)
+    assert data["is_open"] is False
+    assert data["source_url"] == "http://example.com"
+
+
+def test_cli_error(capsys):
+    with patch("hogebrug_status.cli.BridgeStatusChecker") as mock_checker:
+        mock_checker.return_value.get_status.side_effect = BridgeStatusError("kapot")
+        exit_code = main([])
+
+    assert exit_code == 1
+    captured = capsys.readouterr()
+    assert "kon de brugstatus" in captured.err.lower()


### PR DESCRIPTION
## Summary
- add a defensive bridge status checker that consumes Rotterdam open data
- provide a CLI for querying the Hogebrug and return JSON or text output
- document installation, usage, and how the interpretation works

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68cd68cb5a6c8332a04eb705eb648fa1