### PR TITLE
Update default open data endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Voorbeeld uitvoer:
 ```
 De Hogebrug is open. (Veld 'melding' meldt: Brug weer open voor verkeer)
 Laatste melding: 2024-04-20T11:00:00+02:00
-Bron: https://opendata.rotterdam.nl/api/records/1.0/search/
+Bron: https://rotterdam.dataplatform.nl/api/records/1.0/search/
 ```
 
 ## Testen

--- a/src/hogebrug_status/checker.py
+++ b/src/hogebrug_status/checker.py
@@ -20,7 +20,7 @@ __all__ = ["BridgeStatus", "BridgeStatusChecker", "BridgeStatusError"]
 
 
 DEFAULT_DATASET = "brugopeningen"
-DEFAULT_URL = "https://opendata.rotterdam.nl/api/records/1.0/search/"
+DEFAULT_URL = "https://rotterdam.dataplatform.nl/api/records/1.0/search/"
 DEFAULT_ROWS = 5
 DEFAULT_TIMEOUT = 10
 

--- a/src/hogebrug_status/cli.py
+++ b/src/hogebrug_status/cli.py
@@ -32,7 +32,7 @@ def build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument(
         "--url",
-        default="https://opendata.rotterdam.nl/api/records/1.0/search/",
+        default="https://rotterdam.dataplatform.nl/api/records/1.0/search/",
         help="API-endpoint van het open data portaal.",
     )
     parser.add_argument(


### PR DESCRIPTION
## Summary
- update the default API endpoint to rotterdam.dataplatform.nl in the checker and CLI
- refresh README example output to reference the new domain

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68d10cb9a7b483329926aa32c0c87809