### PR TITLE
Configure setuptools package discovery

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,12 @@ dev = [
   "pytest>=7.4",
 ]
 
+[tool.setuptools]
+package-dir = {"" = "src"}
+
+[tool.setuptools.packages.find]
+where = ["src"]
+
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 addopts = "-q"


### PR DESCRIPTION
## Summary
- configure setuptools to discover packages under the src/ directory so editable installs locate the CLI package

## Testing
- pip install -e .[dev] *(fails: setuptools not available in offline environment)*


------
https://chatgpt.com/codex/tasks/task_b_68d10eca93c08332aded7d7dbc15796d